### PR TITLE
Update offence codes in court-case-service

### DIFF
--- a/cases/court-probation-dev/common-platform-hearings/hearing-bloggs.json
+++ b/cases/court-probation-dev/common-platform-hearings/hearing-bloggs.json
@@ -22,12 +22,12 @@
             "offences": [
               {
                 "id": "0c932f0c-282b-418e-b294-8966498b1eef",
-                "offenceLegislation": "JMBBLOGGS Contrary to section 20 of the Offences Against the    Person Act 1861.",
-                "offenceTitle": "JMBBLOGGS Wound / inflict grievous bodily harm without intent",
-                "wording": "JMBBLOGGS on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith",
-                "listingNumber": 3,
-                "offenceDefinitionId": "1136fd5e-d9d3-4df6-a6a6-a79c8530379f",
-                "offenceCode": "CJO3523",
+                "offenceLegislation": "Contrary to section 47 of the Offences Against the Person Act 1861.",
+                "offenceTitle": "Assault a person thereby occasioning them actual bodily harm",
+                "wording": "On 25/11/2023 at Oxford,  you assaulted John Smith, thereby occasioning him, actual bodily harm",
+                "listingNumber": 2,
+                "offenceDefinitionId": "a86115ce-b611-38e3-8300-1d3d653f5b3a",
+                "offenceCode": "OF61102",
                 "plea": {
                   "pleaValue": "not guilty"
                 },

--- a/cases/court-probation-dev/common-platform-hearings/hearing-lauper.json
+++ b/cases/court-probation-dev/common-platform-hearings/hearing-lauper.json
@@ -32,8 +32,8 @@
                 "offenceTitle": "Repetitious song playing (Girls just want to have fun)",
                 "wording": "It's just been on the radio too often.",
                 "listingNumber": 4,
-                "offenceDefinitionId": "1136fd5e-d9d3-4df6-a6a6-a79c8530379f",
-                "offenceCode": "CJO3523"
+                "offenceDefinitionId": "a86115ce-b611-38e3-8300-1d3d653f5b3a",
+                "offenceCode": "OF61102"
               }
             ],
             "personDefendant": {

--- a/cases/court-probation-dev/common-platform-hearings/hearing-laura-king.json
+++ b/cases/court-probation-dev/common-platform-hearings/hearing-laura-king.json
@@ -39,8 +39,8 @@
                 "offenceTitle": "Wound / inflict grievous bodily harm without intent",
                 "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, Jane Smith",
                 "listingNumber": 6,
-                "offenceDefinitionId": "1136fd5e-d9d3-4df6-a6a6-a79c8530379f",
-                "offenceCode": "CJO3523"
+                "offenceDefinitionId": "a86115ce-b611-38e3-8300-1d3d653f5b3a",
+                "offenceCode": "OF61102"
               }
             ],
             "personDefendant": {

--- a/cases/court-probation-dev/common-platform-hearings/hearing-morgan-marston.json
+++ b/cases/court-probation-dev/common-platform-hearings/hearing-morgan-marston.json
@@ -70,22 +70,54 @@
             "id": "%new_defendant_id_2%",
             "offences": [
               {
-                "id": "6a2f41a3-c54c-fce8-32d2-0324e1c32e22",
-                "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
-                "offenceTitle": "Wound / inflict grievous bodily harm without intent (co-defendant)",
-                "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith",
+                "id": "0c932f0c-282b-418e-b294-8966498b1eec",
+                "offenceLegislation": "Contrary to section 47 of the Offences Against the Person Act 1861.",
+                "offenceTitle": "Assault a person thereby occasioning them actual bodily harm",
+                "wording": "On 25/11/2023 at Oxford,  you assaulted John Smith, thereby occasioning him, actual bodily harm",
                 "listingNumber": 1,
-                "offenceDefinitionId": "1136fd5e-d9d3-4df6-a6a6-a79c8530379f",
-                "offenceCode": "CJO3523"
+                "offenceDefinitionId": "a86115ce-b611-38e3-8300-1d3d653f5b3a",
+                "offenceCode": "OF61102",
+                "plea": {
+                  "pleaValue": "not guilty"
+                },
+                "verdict": {
+                  "verdictType": {
+                    "description": "verdict"
+                  }
+                },
+                "judicialResults": [
+                  {
+                    "label": "label",
+                    "resultText": "resultText",
+                    "isConvictedResult": false,
+                    "judicialResultTypeId": "id"
+                  }
+                ]
               },
               {
-                "id": "%new_offence_id%",
-                "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
-                "offenceTitle": "Wound / inflict grievous bodily harm without intent (co-defendant)",
-                "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, Jane Smith",
-                "offenceDefinitionId": "1136fd5e-d9d3-4df6-a6a6-a79c8530379f",
-                "offenceCode": "CJO3523",
-                "listingNo": 3
+                "id": "0c932f0c-282b-418e-b294-8966498b1eeg",
+                "offenceLegislation": "Contrary to section 47 of the Offences Against the Person Act 1861.",
+                "offenceTitle": "Assault a person thereby occasioning them actual bodily harm",
+                "wording": "On 25/11/2023 at Oxford,  you assaulted John Smith, thereby occasioning him, actual bodily harm",
+                "listingNumber": 2,
+                "offenceDefinitionId": "a86115ce-b611-38e3-8300-1d3d653f5b3a",
+                "offenceCode": "OF61102",
+                "plea": {
+                  "pleaValue": "not guilty"
+                },
+                "verdict": {
+                  "verdictType": {
+                    "description": "verdict"
+                  }
+                },
+                "judicialResults": [
+                  {
+                    "label": "label",
+                    "resultText": "resultText",
+                    "isConvictedResult": false,
+                    "judicialResultTypeId": "id"
+                  }
+                ]
               }
             ],
             "personDefendant": {

--- a/cases/court-probation-dev/common-platform-hearings/hearing-morgan.json
+++ b/cases/court-probation-dev/common-platform-hearings/hearing-morgan.json
@@ -35,8 +35,8 @@
                 "offenceTitle": "Wound / inflict grievous bodily harm without intent (sole defendant)",
                 "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, Jane Smith",
                 "listingNumber": 7,
-                "offenceDefinitionId": "1136fd5e-d9d3-4df6-a6a6-a79c8530379f",
-                "offenceCode": "CJO3523"
+                "offenceDefinitionId": "a86115ce-b611-38e3-8300-1d3d653f5b3a",
+                "offenceCode": "OF61102"
               }
             ],
             "personDefendant": {

--- a/cases/court-probation-dev/common-platform-hearings/hearing-new-unmatched.json
+++ b/cases/court-probation-dev/common-platform-hearings/hearing-new-unmatched.json
@@ -26,21 +26,53 @@
             "offences": [
               {
                 "id": "a63d9020-aa6b-4997-92fd-72a692b036de",
-                "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
-                "offenceTitle": "Wound / inflict grievous bodily harm without intent",
-                "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith",
+                "offenceLegislation": "Contrary to section 47 of the Offences Against the Person Act 1861.",
+                "offenceTitle": "Assault a person thereby occasioning them actual bodily harm",
+                "wording": "On 25/11/2023 at Oxford,  you assaulted John Smith, thereby occasioning him, actual bodily harm",
                 "listingNumber": 1,
-                "offenceDefinitionId": "1136fd5e-d9d3-4df6-a6a6-a79c8530379f",
-                "offenceCode": "CJO3523"
+                "offenceDefinitionId": "a86115ce-b611-38e3-8300-1d3d653f5b3a",
+                "offenceCode": "OF61102",
+                "plea": {
+                  "pleaValue": "not guilty"
+                },
+                "verdict": {
+                  "verdictType": {
+                    "description": "verdict"
+                  }
+                },
+                "judicialResults": [
+                  {
+                    "label": "label",
+                    "resultText": "resultText",
+                    "isConvictedResult": false,
+                    "judicialResultTypeId": "id"
+                  }
+                ]
               },
               {
                 "id": "ea1c2cf1-f155-483b-a908-81158a9b2f9b",
-                "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
-                "offenceTitle": "Wound / inflict grievous bodily harm without intent",
-                "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, Jane Smith",
+                "offenceLegislation": "Contrary to section 47 of the Offences Against the Person Act 1861.",
+                "offenceTitle": "Assault a person thereby occasioning them actual bodily harm",
+                "wording": "On 25/11/2023 at Oxford,  you assaulted John Smith, thereby occasioning him, actual bodily harm",
                 "listingNumber": 2,
-                "offenceDefinitionId": "1136fd5e-d9d3-4df6-a6a6-a79c8530379f",
-                "offenceCode": "CJO3523"
+                "offenceDefinitionId": "a86115ce-b611-38e3-8300-1d3d653f5b3a",
+                "offenceCode": "OF61102",
+                "plea": {
+                  "pleaValue": "not guilty"
+                },
+                "verdict": {
+                  "verdictType": {
+                    "description": "verdict"
+                  }
+                },
+                "judicialResults": [
+                  {
+                    "label": "label",
+                    "resultText": "resultText",
+                    "isConvictedResult": false,
+                    "judicialResultTypeId": "id"
+                  }
+                ]
               }
             ],
             "personDefendant": {

--- a/cases/court-probation-dev/common-platform-hearings/hearing-update-morgan.json
+++ b/cases/court-probation-dev/common-platform-hearings/hearing-update-morgan.json
@@ -21,21 +21,53 @@
             "offences": [
               {
                 "id": "a63d9020-aa6b-4997-92fd-72a692b036de",
-                "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
-                "offenceTitle": "Wound / inflict grievous bodily harm without intent (sole defendant)",
-                "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith",
+                "offenceLegislation": "Contrary to section 47 of the Offences Against the Person Act 1861.",
+                "offenceTitle": "Assault a person thereby occasioning them actual bodily harm",
+                "wording": "On 25/11/2023 at Oxford,  you assaulted John Smith, thereby occasioning him, actual bodily harm",
                 "listingNumber": 5,
-                "offenceDefinitionId": "1136fd5e-d9d3-4df6-a6a6-a79c8530379f",
-                "offenceCode": "CJO3523"
+                "offenceDefinitionId": "a86115ce-b611-38e3-8300-1d3d653f5b3a",
+                "offenceCode": "OF61102",
+                "plea": {
+                  "pleaValue": "not guilty"
+                },
+                "verdict": {
+                  "verdictType": {
+                    "description": "verdict"
+                  }
+                },
+                "judicialResults": [
+                  {
+                    "label": "label",
+                    "resultText": "resultText",
+                    "isConvictedResult": false,
+                    "judicialResultTypeId": "id"
+                  }
+                ]
               },
               {
                 "id": "ea1c2cf1-f155-483b-a908-81158a9b2f9b",
-                "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
-                "offenceTitle": "Wound / inflict grievous bodily harm without intent (sole defendant)",
-                "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, Jane Smith",
+                "offenceLegislation": "Contrary to section 47 of the Offences Against the Person Act 1861.",
+                "offenceTitle": "Assault a person thereby occasioning them actual bodily harm",
+                "wording": "On 25/11/2023 at Oxford,  you assaulted John Smith, thereby occasioning him, actual bodily harm",
                 "listingNumber": 7,
-                "offenceDefinitionId": "1136fd5e-d9d3-4df6-a6a6-a79c8530379f",
-                "offenceCode": "CJO3523"
+                "offenceDefinitionId": "a86115ce-b611-38e3-8300-1d3d653f5b3a",
+                "offenceCode": "OF61102",
+                "plea": {
+                  "pleaValue": "not guilty"
+                },
+                "verdict": {
+                  "verdictType": {
+                    "description": "verdict"
+                  }
+                },
+                "judicialResults": [
+                  {
+                    "label": "label",
+                    "resultText": "resultText",
+                    "isConvictedResult": false,
+                    "judicialResultTypeId": "id"
+                  }
+                ]
               }
             ],
             "personDefendant": {


### PR DESCRIPTION
This is because the previous offence codes can't be found when making an API call.

This new offence code exists and should unblock test data into dev