### PR TITLE
Provide permissions to add messages to FIFO resources and fix local setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+/volume

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ echo "✨ Creating a shiny new thing!"
 **Update:** Since the changes to move from long lived credentials to IRSA based auth, we need to create a service pod in the namespace and establish a bash session, using the script `setup-service-pod.bash` which would create a pod and opens a bash session which then can be used to run below scripts.
     By default, the service pod name is `hmpps-probation-in-coourt-utils` and namespace is `court-probation-dev` which can be overwritten by `setup-service-pod.bash --debug_pod_name your-own-debug-pod-name --namespace your-alternate-name-space` 
 
-Run `./subscribe-to-topic.bash --email <your@email.address>` to subscribe to events from the `court-case-events-topic` SNS topic
+Run `./subscribe-to-topic.bash --email <your@email.address>` to subscribe to events from the `court-cases-topic` SNS topic
 
 Run `./populate-cpg-sqs.bash` to push case lists to the `crime-portal-gateway-queue` (To push message to probation-in-court-team-development-crime-portal-gateway-queue)
 
-Run `./populate-matcher-sns.bash` to push some cases to the `court-case-events-topic` SNS topic
+Run `./populate-matcher-sns.bash` to push some cases to the `court-cases-topic` SNS topic
 
 Run `./check-queue.bash` to check if there are any messages on the court-case-matcher queue
 

--- a/check-matcher-dlq.bash
+++ b/check-matcher-dlq.bash
@@ -29,7 +29,7 @@ exit_on_error() {
 if [ $local = "true" ]
 then
   echo "🏠 Running against localstack"
-  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=
   AWS_ACCESS_KEY_ID=

--- a/check-queue.bash
+++ b/check-queue.bash
@@ -28,7 +28,7 @@ exit_on_error() {
 if [[ $local == "true" ]]
 then
   echo "🏠 Running against localstack"
-  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   QUEUE_URL="http://localhost:4566/000000000000/test-queue"
   AWS_ACCESS_KEY_ID=foobar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,21 @@
 version: "3"
 services:
   localstack:
-    image: localstack/localstack:latest
+    container_name: court-case-localstack
+    image: localstack/localstack
     networks:
       - hmpps
-    container_name: court-case-localstack
     ports:
-      - "4566-4597:4566-4597"
-      - 8999:8080
-      - 9080:9080
+      - "127.0.0.1:4566:4566"
+      - "127.0.0.1:4510-4559:4510-4559"
     environment:
       - SERVICES=sqs,sns
       - PORT_WEB_UI=9080
-      - DEBUG=${DEBUG- }
+      - DEBUG=${DEBUG:-0}
       - DATA_DIR=/tmp/localstack/data
-      - DOCKER_HOST=unix:///var/run/docker.sock
       - DEFAULT_REGION=eu-west-2
     volumes:
-      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
-      - $PWD/localstack:/docker-entrypoint-initaws.d
-
 networks:
   hmpps:

--- a/get-subscription.bash
+++ b/get-subscription.bash
@@ -19,7 +19,7 @@ set -e
 if [ $local = "true" ]
 then
   echo "🏠 Running against localstack"
-  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=
   AWS_ACCESS_KEY_ID=

--- a/list-subscribers.bash
+++ b/list-subscribers.bash
@@ -19,7 +19,7 @@ set -e
 if [ $local = "true" ]
 then
   echo "🏠 Running against localstack"
-  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=foobar
   AWS_ACCESS_KEY_ID=foobar

--- a/localstack/setup-sqs.sh
+++ b/localstack/setup-sqs.sh
@@ -16,7 +16,7 @@ aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "h
 aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/court-case-matcher-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"1\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:court-case-matcher-dlq\"}"}'
 
 # Create SNS topic
-TOPIC_ARN=$(aws --endpoint-url http://localhost:4566 sns create-topic --output text --name court-case-events-topic --output text)
+TOPIC_ARN=$(aws --endpoint-url http://localhost:4566 sns create-topic --output text --name court-cases-topic --output text)
 aws --endpoint-url http://localhost:4566 sns subscribe --topic-arn "$TOPIC_ARN" --protocol sqs --notification-endpoint "$QUEUE_ARN" --output text
 
 echo "SQS and SNS Configured"

--- a/localstack/setup-sqs.sh
+++ b/localstack/setup-sqs.sh
@@ -6,17 +6,19 @@ export AWS_SECRET_ACCESS_KEY=foobar
 export AWS_DEFAULT_REGION=eu-west-2
 export PAGER=
 
-CPG_DLQ_ARN=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-dlq --output text)
-aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue
-CCM_DLQ_ARN=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name court-case-matcher-dlq --output text)
-QUEUE_ARN=$(aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-queue --output text)
+CPG_DLQ_ARN=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-dlq.fifo --attributes "FifoQueue=true" --output text)
+aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name crime-portal-gateway-queue.fifo --attributes "FifoQueue=true"
+CCM_DLQ_ARN=$(aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-dlq.fifo --attributes "FifoQueue=true" --output text)
+QUEUE_URL=$(aws --endpoint-url http://localhost:4566 sqs create-queue --queue-name court-case-matcher-queue.fifo --attributes "FifoQueue=true" --output text)
+QUEUE_ARN=$(aws sqs get-queue-attributes --queue-url ${QUEUE_URL} --attribute-names QueueArn --endpoint-url=http://localhost:4566)
 
-sleep 2
-aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/crime-portal-gateway-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"1\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-dlq\"}"}'
-aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/court-case-matcher-queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"1\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:court-case-matcher-dlq\"}"}'
+# sleep 2
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/crime-portal-gateway-queue.fifo" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"1\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:crime-portal-gateway-dlq.fifo\"}"}'
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/court-case-matcher-queue.fifo" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"1\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:court-case-matcher-dlq.fifo\"}"}'
 
-# Create SNS topic
-TOPIC_ARN=$(aws --endpoint-url http://localhost:4566 sns create-topic --output text --name court-cases-topic --output text)
+# # Create SNS topic
+TOPIC_ARN=$(aws --endpoint-url http://localhost:4566 sns create-topic --output text --name court-cases-topic.fifo --attributes '{"FifoTopic":"true", "ContentBasedDeduplication":"true"}' --output text)
+
 aws --endpoint-url http://localhost:4566 sns subscribe --topic-arn "$TOPIC_ARN" --protocol sqs --notification-endpoint "$QUEUE_ARN" --output text
 
 echo "SQS and SNS Configured"

--- a/populate-cpg-sqs.bash
+++ b/populate-cpg-sqs.bash
@@ -30,7 +30,7 @@ exit_on_error() {
 if [ $local = "true" ]
 then
   echo "🏠 Running against localstack"
-  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=
   AWS_ACCESS_KEY_ID=

--- a/populate-matcher-sns-cp.bash
+++ b/populate-matcher-sns-cp.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 namespace=${$namespace:-court-probation-dev}
-topic_secret=court-case-events-topic
+topic_secret=court-cases-topic
 local=false
 files=
 message_type=COMMON_PLATFORM_HEARING
@@ -42,7 +42,7 @@ exit_on_error() {
 if [[ $local = "true" ]]
 then
   echo "🏠 Running against localstack"
-  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=
   AWS_ACCESS_KEY_ID=

--- a/populate-matcher-sns-cp.bash
+++ b/populate-matcher-sns-cp.bash
@@ -1,5 +1,9 @@
 #!/bin/bash
-namespace=${$namespace:-court-probation-dev}
+if [ -z "${namespace}" ]; then
+  namespace="court-probation-dev"
+else
+  namespace="$namespace"
+fi
 topic_secret=court-cases-topic
 local=false
 files=
@@ -42,18 +46,17 @@ exit_on_error() {
 if [[ $local = "true" ]]
 then
   echo "🏠 Running against localstack"
-  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
+  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic.fifo"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=
   AWS_ACCESS_KEY_ID=
-else
-  export TOPIC_ARN=$MATCHER_TOPIC_ARN
 fi
+
+export TOPIC_ARN=$MATCHER_TOPIC_ARN
 
 # Check the topic is accessible
 echo "📡 Checking connection to SNS..."
 aws sns get-topic-attributes --topic-arn "$TOPIC_ARN" $OPTIONS > /dev/null
-#exit_on_error $? !!
 
 if [[ -n "${cases_path}" ]]
 then
@@ -62,8 +65,9 @@ fi
 CASES_PATH="${cp_base_path}${cases_path}"
 FILES=$(find $CASES_PATH -maxdepth $recurse_max_depth -type f)
 echo "📂 Checking for cases in ${CASES_PATH}"
-HEARING_DATE=$(date +"%Y-%m-%d")
-TOMORROW_DATE=$(date -d "+1 days" +"%Y-%m-%d")
+HEARING_DATE=$(gdate +"%Y-%m-%d")
+TOMORROW_DATE=$(gdate -d "+1 days" +"%Y-%m-%d")
+MSG_GROUP_ID="COURT_HEARING_EVENT_RECEIVER"
 
 i=0
 echo "The files are ... $FILES"
@@ -110,10 +114,8 @@ do
     fi
     
     MSG_ATTRIBS="{\"messageType\" : { \"DataType\":\"String\", \"StringValue\":\"$message_type\"}, \"hearingEventType\" : { \"DataType\":\"String\", \"StringValue\":\"${event_type}\"}}"
-
     echo "${PAYLOAD}"
-    aws sns publish --topic-arn "$TOPIC_ARN" --message "$PAYLOAD" --message-attributes "$MSG_ATTRIBS" $OPTIONS
-    #exit_on_error $? !!
+    aws sns publish --topic-arn "$TOPIC_ARN" --message "$PAYLOAD" --message-group "$MSG_GROUP_ID" --message-attributes "$MSG_ATTRIBS" $OPTIONS
   fi
 done
 

--- a/populate-matcher-sns.bash
+++ b/populate-matcher-sns.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 namespace=${$namespace:-court-probation-dev}
-topic_secret=court-case-events-topic
+topic_secret=court-cases-topic
 local=false
 files=
 message_type=LIBRA_COURT_CASE
@@ -35,7 +35,7 @@ exit_on_error() {
 if [ "$local" = "true" ]
 then
   echo "🏠 Running against localstack"
-  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=
   AWS_ACCESS_KEY_ID=

--- a/purge-queue.bash
+++ b/purge-queue.bash
@@ -29,7 +29,7 @@ exit_on_error() {
 if [ $local = "true" ]
 then
   echo "🏠 Running against localstack"
-  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   QUEUE_URL="http://localhost:4566/000000000000/test-queue"
   AWS_ACCESS_KEY_ID=

--- a/receive-queue.bash
+++ b/receive-queue.bash
@@ -30,7 +30,7 @@ exit_on_error() {
 if [ $local = "true" ]
 then
   echo "🏠 Running against localstack"
-  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   QUEUE_URL="http://localhost:4566/000000000000/test-queue"
   AWS_ACCESS_KEY_ID=foobar

--- a/setup-service-pod.bash
+++ b/setup-service-pod.bash
@@ -34,7 +34,7 @@ service_pod_exists="$(kubectl get pods $debug_pod_name || echo 'NotFound')"
 if [ "$local" = "true" ]
 then
   echo "🏠 Running against localstack"
-  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=
   AWS_ACCESS_KEY_ID=
@@ -46,7 +46,7 @@ else
     fi
   # Get credentials and queue details from namespace secret
   echo "🔑 Getting matcher topic arn from secrets..."
-  secret_json=$(cloud-platform decode-secret -s court-case-events-topic -n $namespace --skip-version-check)
+  secret_json=$(cloud-platform decode-secret -s court-cases-topic -n $namespace --skip-version-check)
   export MATCHER_TOPIC_ARN=$(echo "$secret_json" | jq -r .data.topic_arn)
 
   echo "🔑 Getting matcher dlq arn from secrets..."

--- a/setup-service-pod.bash
+++ b/setup-service-pod.bash
@@ -85,6 +85,6 @@ else
       --env "REDIS_HOST=$REDIS_HOST" \
       --env "REDIS_AUTH_TOKEN=$RREDIS_AUTH_TOKEN" \
     -it --rm $debug_pod_name --image=quay.io/hmpps/hmpps-probation-in-court-utils:latest \
-     --restart=Never --overrides='{ "spec": { "serviceAccount": "court-case-service" } }'
+     --restart=Never --overrides='{ "spec": { "serviceAccount": "court-facing-api" } }'
 fi
 

--- a/subscribe-to-topic.bash
+++ b/subscribe-to-topic.bash
@@ -26,7 +26,7 @@ fi
 if [ $local = "true" ]
 then
   echo "🏠 Running against localstack"
-  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  MATCHER_TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=
   AWS_ACCESS_KEY_ID=

--- a/unsubscribe.bash
+++ b/unsubscribe.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 namespace=court-probation-dev
-topic_secret=court-case-events-topic
+topic_secret=court-cases-topic
 local=false
 subscription_arn=
 
@@ -21,7 +21,7 @@ set -e
 if [ $local = "true" ]
 then
   echo "🏠 Running against localstack"
-  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=
   AWS_ACCESS_KEY_ID=

--- a/update-subscription.bash
+++ b/update-subscription.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 namespace=court-probation-dev
-topic_secret=court-case-events-topic
+topic_secret=court-cases-topic
 local=false
 email=
 
@@ -21,7 +21,7 @@ set -e
 if [ $local = "true" ]
 then
   echo "🏠 Running against localstack"
-  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+  TOPIC_ARN="arn:aws:sns:eu-west-2:000000000000:court-cases-topic"
   OPTIONS="--endpoint-url http://localhost:4566"
   AWS_ACCESS_KEY_ID=
   AWS_ACCESS_KEY_ID=


### PR DESCRIPTION

Allow publishing messages to new fifo SNS and SQS resources. This unblocks the toolkit.

Fix local setup (fix localstack in docker-compose)