### PR TITLE
Fix date tool used in populate script

### DIFF
--- a/populate-matcher-sns-cp.bash
+++ b/populate-matcher-sns-cp.bash
@@ -62,11 +62,19 @@ if [[ -n "${cases_path}" ]]
 then
   recurse_max_depth=10
 fi
+
 CASES_PATH="${cp_base_path}${cases_path}"
 FILES=$(find $CASES_PATH -maxdepth $recurse_max_depth -type f)
 echo "📂 Checking for cases in ${CASES_PATH}"
-HEARING_DATE=$(gdate +"%Y-%m-%d")
-TOMORROW_DATE=$(gdate -d "+1 days" +"%Y-%m-%d")
+
+if [ -x "$(command -v gdate)" ]; then
+  HEARING_DATE=$(gdate +"%Y-%m-%d")
+  TOMORROW_DATE=$(gdate -d "+1 days" +"%Y-%m-%d")
+else
+  HEARING_DATE=$(date +"%Y-%m-%d")
+  TOMORROW_DATE=$(date -d "+1 days" +"%Y-%m-%d")
+fi
+
 MSG_GROUP_ID="COURT_HEARING_EVENT_RECEIVER"
 
 i=0


### PR DESCRIPTION
Use different GNU date tools depending on platform used e.g. use gdate when running the script locally on macos but use date when running in linux in a k8s linux service pod

- Use gdate if on macos and running scripts locally
- Use date coreutil if on linux